### PR TITLE
Use the correct phase correction factors for round>1

### DIFF
--- a/sarsim/simjob.py
+++ b/sarsim/simjob.py
@@ -450,7 +450,10 @@ def _autofocus_pafo(state: simstate.SarSimParameterState, progress_callback: Cal
                     sample_points = last_optimum + indices * sample_spacing
 
                 # Get the "subtract, then add rotated" factors
-                candidate_factors = np.expm1(1j * sample_points)
+                if round == 1: #in the first round we have e^\chi - 1
+                    candidate_factors = np.expm1(1j * sample_points)
+                else: # in the subsequent rounds we need to consider the previous correction
+                    candidate_factors = np.exp(1j * sample_points) - np.exp(1j * optimal_phases[round-1, az_index])
                 # Build Image and apply sharpnes metric (with summing)
                 if CUDA_NUMBA_AVAILABLE:
                     blocksize = (16,)
@@ -484,7 +487,10 @@ def _autofocus_pafo(state: simstate.SarSimParameterState, progress_callback: Cal
                 optimal_phase = last_optimum
 
             # Apply:
-            correction_factor = np.expm1(1j*optimal_phase)
+            if round == 1: #in the first round we have e^\chi - 1
+                correction_factor = np.expm1(1j * optimal_phase)
+            else: # in the subsequent rounds we need to consider the previous correction
+                correction_factor = np.exp(1j * optimal_phase) - np.exp(1j * optimal_phases[round-1, az_index])
             if CUDA_NUMBA_AVAILABLE:
                 blocksize = (16,)
                 gridsize = (math.ceil(len(ac_image) / blocksize[0]),)


### PR DESCRIPTION
Der PAFO Code hat vermutlich einen Bug für rounds>1. Um die "substract, than add rotated" faktoren zu berechnen wird [np.expm1](https://github.com/IMS-AS-LUH/sar-sim/blob/main/sarsim/simjob.py#L453) benutzt. Das ist für die erste Runde korrekt, weil das Single-Pulse-Bild aus den Rohdaten eine Phasedrehung von 0° hat. Ab der zweiten Runde muss aber beachtet werden, dass ja schon eine Phasekorrektur vorliegt, und die Rohdaten daher nicht das Single-Puls-Bild ergeben, was direkt abgezogen werden kann.

Korrekt wäre vermutlich hier die Phasenkorrektur aus der letzten Runde mit zu betrachten.