### PR TITLE
GUI Fixes and Improvement

### DIFF
--- a/sarsim/gui.py
+++ b/sarsim/gui.py
@@ -543,9 +543,11 @@ class SarGuiParameterDock():
             value = state.get_value(parameter)
             if parameter.type.suggestions is not None:
                 box.setCurrentText(str(value))
-            elif parameter.type.type in [float, int]:
+            elif parameter.type.type is float:
                 factor = box.property('si_factor')
                 box.setValue(value / factor)
+            elif parameter.type.type is int:
+                box.setValue(value)
             elif parameter.type.type is str or parameter.type.choices is not None:
                 if isinstance(box, QComboBox):
                     box.setCurrentText(self._get_dict_key_by_value(parameter.type.choices, value))
@@ -795,7 +797,7 @@ class SarGuiMainFrame(QMainWindow):
             win.do_autorange()
 
     def _show_progress(self, progress: float, message: str):
-        self._progress_bar.setValue(progress*1000)
+        self._progress_bar.setValue(int(progress*1000))
         self._progress_label.setText(message)
 
     def _show_results(self, result: simjob.SimResult):

--- a/sarsim/gui.py
+++ b/sarsim/gui.py
@@ -601,7 +601,11 @@ class SarGuiMainFrame(QMainWindow):
         self._first_run = True
         for win in self._windows:
             win.mark_stale()
-        
+
+        # By default, autofocus and flight path are off
+        self._plot_fpath.showMinimized()
+        self._plot_window_af.showMinimized()
+
         # Default view
         self.mdi.tileSubWindows()
         self.showMaximized()

--- a/sarsim/simstate.py
+++ b/sarsim/simstate.py
@@ -113,8 +113,8 @@ SAR_SIM_PARAMETERS = (
     SimParameter(_METERS, 'image_stop_x', 'img_xm', 1, category='Azimuth Compression'),
     SimParameter(_METERS, 'image_stop_y', 'img_ym', 1, category='Azimuth Compression'),
 
-    SimParameter(_COUNT, 'image_count_x', 'n_x', 501, category='Azimuth Compression'),
-    SimParameter(_COUNT, 'image_count_y', 'n_y', 501, category='Azimuth Compression'),
+    SimParameter(_COUNT, 'image_count_x', 'n_x', 201, category='Azimuth Compression'),
+    SimParameter(_COUNT, 'image_count_y', 'n_y', 201, category='Azimuth Compression'),
 
     # this is in Az.Comp. because it currently only affects that. It is not used in the actual FMCW simulation
     # is therefore should be 0 for simulated data, and -0.052 for data from the RUB sensor


### PR DESCRIPTION
**Fixes:**
- Qt Widgets for integer parameters got float which crashed the whole GUI immediately (at least on Windows)

**Improvements:**
- Reduced default image size, so first run for new users is faster (especially without cuda)
- Added progress bar callback for non-cuda azimuth compression (so new users do not think GUI freezes)
- Reduced initial GUI clutter by showing only the original three views (since autofocus is off by default)